### PR TITLE
Bugfix wkhtmltopdf_options

### DIFF
--- a/wkhtmltopdf_server.js
+++ b/wkhtmltopdf_server.js
@@ -15,7 +15,7 @@ function html_request(request, response) {
     'use strict';
     var
         unique_id = new Date().toISOString() + '_' + Math.floor(Math.random() * 1000),
-        wkhtmltopdf_options = request.headers.wkhtmltopdf_options ? request.headers.wkhtmltopdf_options.split(' ') : ['--quiet'],
+        wkhtmltopdf_options = request.headers.wkhtmltopdf_options ? request.headers.wkhtmltopdf_options : '--quiet',
         spawn_wkhtmltopdf;
 
     if (request.url === '/favicon.ico') {


### PR DESCRIPTION
Was converted to a list, should be a string, Caused the execution to crash, when more then option added.
